### PR TITLE
实现当没有传入证书时只拦截和处理 http 请求，跳过所有 https 请求。

### DIFF
--- a/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareConfig.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/NetBareConfig.java
@@ -75,11 +75,11 @@ public final class NetBareConfig {
     /**
      * Create a default config using {@link HttpVirtualGatewayFactory} for HTTP protocol.
      *
-     * @param jks JSK instance, not null.
+     * @param jks JSK instance, skip https when jks is empty.
      * @param interceptors A collection of {@link HttpInterceptorFactory}.
      * @return A NetBare config instance.
      */
-    public static NetBareConfig defaultHttpConfig(@NonNull JKS jks,
+    public static NetBareConfig defaultHttpConfig(JKS jks,
                                                   List<HttpInterceptorFactory> interceptors) {
         return defaultConfig().newBuilder()
                 .setVirtualGatewayFactory(new HttpVirtualGatewayFactory(jks, interceptors))

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSniffInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSniffInterceptor.java
@@ -74,7 +74,7 @@ import java.nio.ByteBuffer;
     @Override
     protected void intercept(@NonNull HttpResponseChain chain, @NonNull ByteBuffer buffer,
                              int index) throws IOException {
-        if ((mType == TYPE_INVALID) || (mType == TYPE_WHITELIST)) {
+        if ((mType == TYPE_INVALID) || (mType == TYPE_WHITELIST) || (mType == TYPE_HTTPS && sslEngineFactory == null)) {
             chain.processFinal(buffer);
             return;
         }

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSniffInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSniffInterceptor.java
@@ -19,6 +19,7 @@ import android.support.annotation.NonNull;
 
 import com.github.megatronking.netbare.NetBareLog;
 import com.github.megatronking.netbare.ssl.SSLCodec;
+import com.github.megatronking.netbare.ssl.SSLEngineFactory;
 import com.github.megatronking.netbare.ssl.SSLWhiteList;
 
 import java.io.IOException;
@@ -40,11 +41,13 @@ import java.nio.ByteBuffer;
     private static final int TYPE_WHITELIST = 4;
 
     private final HttpSession mSession;
+    private final SSLEngineFactory sslEngineFactory;
 
     private int mType;
 
-    /* package */ HttpSniffInterceptor(HttpSession session) {
+    /* package */ HttpSniffInterceptor(HttpSession session, SSLEngineFactory sslEngineFactory) {
         this.mSession = session;
+        this.sslEngineFactory = sslEngineFactory;
     }
 
     @Override
@@ -61,7 +64,7 @@ import java.nio.ByteBuffer;
         if (mType == TYPE_HTTPS) {
             mSession.isHttps = true;
         }
-        if ((mType == TYPE_INVALID) || (mType == TYPE_WHITELIST)) {
+        if ((mType == TYPE_INVALID) || (mType == TYPE_WHITELIST) || (mType == TYPE_HTTPS && sslEngineFactory == null)) {
             chain.processFinal(buffer);
             return;
         }

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSniffInterceptor.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpSniffInterceptor.java
@@ -61,7 +61,7 @@ import java.nio.ByteBuffer;
                 mType = chain.request().host() == null ? TYPE_INVALID : verifyHttpType(buffer);
             }
         }
-        if (mType == TYPE_HTTPS) {
+        if (mType == TYPE_HTTPS && sslEngineFactory != null) {
             mSession.isHttps = true;
         }
         if ((mType == TYPE_INVALID) || (mType == TYPE_WHITELIST) || (mType == TYPE_HTTPS && sslEngineFactory == null)) {

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpVirtualGateway.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpVirtualGateway.java
@@ -61,7 +61,7 @@ import java.util.List;
         if (jks != null){
             try {
                 sslEngineFactory = SSLEngineFactory.get(jks);
-            } catch (GeneralSecurityException | IOException e) {
+            } catch (GeneralSecurityException | IOException | NullPointerException e) {
                 //Ignore
             }
         }

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpVirtualGateway.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpVirtualGateway.java
@@ -57,18 +57,20 @@ import java.util.List;
         this.mHttpZygoteRequest = new HttpZygoteRequest(request, sessionFactory);
         this.mHttpZygoteResponse = new HttpZygoteResponse(response, sessionFactory);
 
-        SSLEngineFactory sslEngineFactory;
-        try {
-            sslEngineFactory = SSLEngineFactory.get(jks);
-        } catch (GeneralSecurityException | IOException e) {
-            sslEngineFactory = null;
+        SSLEngineFactory sslEngineFactory = null;
+        if (jks != null){
+            try {
+                sslEngineFactory = SSLEngineFactory.get(jks);
+            } catch (GeneralSecurityException | IOException e) {
+                //Ignore
+            }
         }
 
         // Add default interceptors.
         HttpSSLCodecInterceptor codecInterceptor = new HttpSSLCodecInterceptor(sslEngineFactory, request, response);
         this.mInterceptors = new ArrayList<>(8);
 
-        mInterceptors.add(new HttpSniffInterceptor(sessionFactory.create(session.id)));
+        mInterceptors.add(new HttpSniffInterceptor(sessionFactory.create(session.id), sslEngineFactory));
         mInterceptors.add(codecInterceptor);
         mInterceptors.add(new Http2SniffInterceptor(codecInterceptor));
         mInterceptors.add(new Http2DecodeInterceptor(codecInterceptor, mHttpZygoteRequest, mHttpZygoteResponse));

--- a/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpVirtualGatewayFactory.java
+++ b/netbare-core/src/main/java/com/github/megatronking/netbare/http/HttpVirtualGatewayFactory.java
@@ -45,7 +45,7 @@ public class HttpVirtualGatewayFactory implements VirtualGatewayFactory {
      * @param factories a collection of {@link HttpInterceptorFactory}.
      * @return A instance of {@link HttpVirtualGatewayFactory}.
      */
-    public HttpVirtualGatewayFactory(@NonNull JKS jks,
+    public HttpVirtualGatewayFactory(JKS jks,
                                      @NonNull List<HttpInterceptorFactory> factories) {
         this.mJKS = jks;
         this.mFactories = factories;
@@ -63,7 +63,7 @@ public class HttpVirtualGatewayFactory implements VirtualGatewayFactory {
      * @param factories a collection of {@link HttpInterceptorFactory}.
      * @return A instance of {@link HttpVirtualGatewayFactory}.
      */
-    public static VirtualGatewayFactory create(@NonNull JKS authority,
+    public static VirtualGatewayFactory create(JKS authority,
                                                @NonNull List<HttpInterceptorFactory> factories) {
         return new HttpVirtualGatewayFactory(authority, factories);
     }


### PR DESCRIPTION
当只想用这个库拦截一个 http 请求时需要进行不必要的证书安装过程，并且MITM攻击在 Android 7.0 以上只能通过虚拟环境或者Root实现，并且还存在 CA Pinning 的情况，而导致其他不需要拦截的 https 请求产生错误，所以实现了这个功能来实现只拦截 http，使用的时候不用创建和安装证书 JKS 传入 null 即可。

关联这个问题 #39 