### PR TITLE
fix java.lang.SecurityException when  targetSdkVersion >= 28

### DIFF
--- a/netbare-core/src/main/AndroidManifest.xml
+++ b/netbare-core/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application>
         <activity android:name=".ssl.CertificateInstallActivity"


### PR DESCRIPTION
fix 

`java.lang.SecurityException: Permission Denial: startForeground requires android.permission.FOREGROUND_SERVICE`

this permission is needed on targetSdkVersion >= 28

adding this won't cause any error on targetSdkVersion < 28

not tested but may work